### PR TITLE
refactor!: rename to `@capawesome/capacitor-file-picker`

### DIFF
--- a/CapawesomeCapacitorFilePicker.podspec
+++ b/CapawesomeCapacitorFilePicker.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'RobingenzCapacitorFilePicker'
+  s.name = 'CapawesomeCapacitorFilePicker'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author = package['author']
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-  s.ios.deployment_target  = '12.0'
+  s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
 end

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 <p align="center"><br><img src="https://user-images.githubusercontent.com/236501/85893648-1c92e880-b7a8-11ea-926d-95355b8175c7.png" width="128" height="128" /></p>
 <h3 align="center">File Picker</h3>
-<p align="center"><strong><code>@robingenz/capacitor-file-picker</code></strong></p>
+<p align="center"><strong><code>@capawesome/capacitor-file-picker</code></strong></p>
 <p align="center">
   Capacitor plugin that allows the user to select a file.
 </p>
 
 <p align="center">
   <img src="https://img.shields.io/maintenance/yes/2022?style=flat-square" />
-  <a href="https://github.com/robingenz/capacitor-file-picker/actions?query=workflow%3A%22CI%22"><img src="https://img.shields.io/github/workflow/status/robingenz/capacitor-file-picker/CI/main?style=flat-square" /></a>
-  <a href="https://www.npmjs.com/package/@robingenz/capacitor-file-picker"><img src="https://img.shields.io/npm/l/@robingenz/capacitor-file-picker?style=flat-square" /></a>
+  <a href="https://github.com/capawesome-team/capacitor-file-picker/actions?query=workflow%3A%22CI%22"><img src="https://img.shields.io/github/workflow/status/capawesome-team/capacitor-file-picker/CI/main?style=flat-square" /></a>
+  <a href="https://www.npmjs.com/package/@capawesome/capacitor-file-picker"><img src="https://img.shields.io/npm/l/@capawesome/capacitor-file-picker?style=flat-square" /></a>
 <br>
-  <a href="https://www.npmjs.com/package/@robingenz/capacitor-file-picker"><img src="https://img.shields.io/npm/dw/@robingenz/capacitor-file-picker?style=flat-square" /></a>
-  <a href="https://www.npmjs.com/package/@robingenz/capacitor-file-picker"><img src="https://img.shields.io/npm/v/@robingenz/capacitor-file-picker?style=flat-square" /></a>
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<a href="#contributors-"><img src="https://img.shields.io/badge/all%20contributors-1-orange?style=flat-square" /></a>
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
+  <a href="https://www.npmjs.com/package/@capawesome/capacitor-file-picker"><img src="https://img.shields.io/npm/dw/@capawesome/capacitor-file-picker?style=flat-square" /></a>
+  <a href="https://www.npmjs.com/package/@capawesome/capacitor-file-picker"><img src="https://img.shields.io/npm/v/@capawesome/capacitor-file-picker?style=flat-square" /></a>
+  <a href="https://github.com/capawesome-team"><img src="https://img.shields.io/badge/part%20of-capawesome-%234f46e5?style=flat-square" /></a>
 </p>
 
 ## Maintainers
@@ -23,10 +21,18 @@
 | ---------- | ----------------------------------------- | --------------------------------------------- |
 | Robin Genz | [robingenz](https://github.com/robingenz) | [@robin_genz](https://twitter.com/robin_genz) |
 
+## Sponsors
+
+This is an MIT-licensed open source project.
+It can grow thanks to the support by these awesome people.
+If you'd like to join them, please read more [here](https://github.com/sponsors/capawesome-team).
+
+<!-- sponsors --><!-- sponsors -->
+
 ## Installation
 
 ```bash
-npm install @robingenz/capacitor-file-picker
+npm install @capawesome/capacitor-file-picker
 npx cap sync
 ```
 
@@ -41,7 +47,7 @@ A working example can be found here: [robingenz/capacitor-plugin-demo](https://g
 ## Usage
 
 ```typescript
-import { FilePicker } from '@robingenz/capacitor-file-picker';
+import { FilePicker } from '@capawesome/capacitor-file-picker';
 
 const pickFiles = async () => {
   const result = await FilePicker.pickFiles({
@@ -68,8 +74,8 @@ const appendFileToFormData = async () => {
 
 <docgen-index>
 
-* [`pickFiles(...)`](#pickfiles)
-* [Interfaces](#interfaces)
+- [`pickFiles(...)`](#pickfiles)
+- [Interfaces](#interfaces)
 
 </docgen-index>
 
@@ -90,18 +96,15 @@ Open the file picker that allows the user to select one or more files.
 
 **Returns:** <code>Promise&lt;<a href="#pickfilesresult">PickFilesResult</a>&gt;</code>
 
---------------------
-
+---
 
 ### Interfaces
-
 
 #### PickFilesResult
 
 | Prop        | Type                |
 | ----------- | ------------------- |
 | **`files`** | <code>File[]</code> |
-
 
 #### File
 
@@ -113,7 +116,6 @@ Open the file picker that allows the user to select one or more files.
 | **`mimeType`** | <code>string</code> | The mime type of the file.                                                                                           |
 | **`size`**     | <code>number</code> | The size of the file in bytes.                                                                                       |
 | **`blob`**     | <code>Blob</code>   | The Blob instance of the file. Only available on Web.                                                                |
-
 
 #### PickFilesOptions
 
@@ -127,8 +129,8 @@ Open the file picker that allows the user to select one or more files.
 
 ## Changelog
 
-See [CHANGELOG.md](https://github.com/robingenz/capacitor-file-picker/blob/main/CHANGELOG.md).
+See [CHANGELOG.md](https://github.com/capawesome-team/capacitor-file-picker/blob/main/CHANGELOG.md).
 
 ## License
 
-See [LICENSE](https://github.com/robingenz/capacitor-file-picker/blob/main/LICENSE).
+See [LICENSE](https://github.com/capawesome-team/capacitor-file-picker/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ const appendFileToFormData = async () => {
 
 <docgen-index>
 
-- [`pickFiles(...)`](#pickfiles)
-- [Interfaces](#interfaces)
+* [`pickFiles(...)`](#pickfiles)
+* [Interfaces](#interfaces)
 
 </docgen-index>
 
@@ -96,15 +96,18 @@ Open the file picker that allows the user to select one or more files.
 
 **Returns:** <code>Promise&lt;<a href="#pickfilesresult">PickFilesResult</a>&gt;</code>
 
----
+--------------------
+
 
 ### Interfaces
+
 
 #### PickFilesResult
 
 | Prop        | Type                |
 | ----------- | ------------------- |
 | **`files`** | <code>File[]</code> |
+
 
 #### File
 
@@ -116,6 +119,7 @@ Open the file picker that allows the user to select one or more files.
 | **`mimeType`** | <code>string</code> | The mime type of the file.                                                                                           |
 | **`size`**     | <code>number</code> | The size of the file in bytes.                                                                                       |
 | **`blob`**     | <code>Blob</code>   | The Blob instance of the file. Only available on Web.                                                                |
+
 
 #### PickFilesOptions
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.robingenz.capacitorjs.plugins.filepicker">
+    package="io.capawesome.capacitorjs.plugins.filepicker">
 </manifest>

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
@@ -1,4 +1,4 @@
-package dev.robingenz.capacitorjs.plugins.filepicker;
+package io.capawesome.capacitorjs.plugins.filepicker;
 
 import android.database.Cursor;
 import android.net.Uri;

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
@@ -1,4 +1,4 @@
-package dev.robingenz.capacitorjs.plugins.filepicker;
+package io.capawesome.capacitorjs.plugins.filepicker;
 
 import android.app.Activity;
 import android.content.Intent;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,22 @@
 {
-  "name": "@robingenz/capacitor-file-picker",
+  "name": "@capawesome/capacitor-file-picker",
   "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@robingenz/capacitor-file-picker",
+      "name": "@capawesome/capacitor-file-picker",
       "version": "0.3.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/capawesome-team/"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/capawesome"
+        }
+      ],
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robingenz/capacitor-file-picker",
+  "name": "@capawesome/capacitor-file-picker",
   "version": "0.3.1",
   "description": "Capacitor plugin that allows the user to select a file.",
   "main": "dist/plugin.cjs.js",
@@ -11,17 +11,27 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "RobingenzCapacitorFilePicker.podspec"
+    "CapawesomeCapacitorFilePicker.podspec"
   ],
   "author": "Robin Genz <mail@robingenz.dev>",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/robingenz/capacitor-file-picker.git"
+    "url": "git+https://github.com/capawesome-team/capacitor-file-picker.git"
   },
   "bugs": {
-    "url": "https://github.com/robingenz/capacitor-file-picker/issues"
+    "url": "https://github.com/capawesome-team/capacitor-file-picker/issues"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/capawesome-team/"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/capawesome"
+    }
+  ],
   "keywords": [
     "capacitor",
     "plugin",
@@ -77,5 +87,8 @@
     "android": {
       "src": "android"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: This plugin was renamed to `@capawesome/capacitor-file-picker`. Please install the new npm package and run `npx cap sync`.