### PR TITLE
fix(android): files of type `text/csv` are not selectable

### DIFF
--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
@@ -59,7 +59,9 @@ public class FilePickerPlugin extends Plugin {
         }
         try {
             List<String> typesList = types.toList();
-            Collections.replaceAll(typesList, "text/csv", "text/comma-separated-values");
+            if (typesList.contains("text/csv")) {
+                typesList.add("text/comma-separated-values");
+            }
             return typesList.toArray(new String[0]);
         } catch (JSONException exception) {
             Logger.error("parseTypesOption failed.", exception);


### PR DESCRIPTION
Close #50 