### PR TITLE
fix: add 'throws' from Android Studio complaints

### DIFF
--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
@@ -91,7 +91,7 @@ public class FilePicker {
     }
 
     @Nullable
-    public Long getDurationFromUri(Uri uri) {
+    public Long getDurationFromUri(Uri uri) throws IOException {
         if (isVideoUri(uri)) {
             MediaMetadataRetriever retriever = new MediaMetadataRetriever();
             retriever.setDataSource(bridge.getContext(), uri);
@@ -104,7 +104,7 @@ public class FilePicker {
     }
 
     @Nullable
-    public FileResolution getHeightAndWidthFromUri(Uri uri) {
+    public FileResolution getHeightAndWidthFromUri(Uri uri) throws IOException {
         if (isImageUri(uri)) {
             BitmapFactory.Options options = new BitmapFactory.Options();
             options.inJustDecodeBounds = true;

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePickerPlugin.java
@@ -13,6 +13,8 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.ActivityCallback;
 import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONException;
@@ -106,7 +108,7 @@ public class FilePickerPlugin extends Plugin {
     }
 
     @ActivityCallback
-    private void pickFilesResult(PluginCall call, ActivityResult result) {
+    private void pickFilesResult(PluginCall call, ActivityResult result) throws IOException {
         if (call == null) {
             return;
         }
@@ -125,7 +127,7 @@ public class FilePickerPlugin extends Plugin {
         }
     }
 
-    private JSObject createPickFilesResult(@Nullable Intent data, boolean readData) {
+    private JSObject createPickFilesResult(@Nullable Intent data, boolean readData) throws IOException {
         JSObject callResult = new JSObject();
         List<JSObject> filesResultList = new ArrayList<>();
         if (data == null) {


### PR DESCRIPTION
Compiling the current version o Android Studio he complaints about unreported exceptions.

This is a very simple fix.

```zsh
[capacitor]         > Task :capawesome-capacitor-file-picker:compileDebugJavaWithJavac FAILED
[capacitor]         /node_modules/@capawesome/capacitor-file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java:100: error: unreported exception IOException; must be caught or declared to be thrown
[capacitor]         retriever.release();
[capacitor]         ^
[capacitor]         /node_modules/@capawesome/capacitor-file-picker/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java:123: error: unreported exception IOException; must be caught or declared to be thrown
[capacitor]         retriever.release();
[capacitor]         ^
[capacitor]         2 errors
[capacitor]         
[capacitor]         FAILURE: Build failed with an exception.
```