### PR TITLE
fix(ios)!: invalid values for `duration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Only available on Android and iOS.
 | ---------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------- | ----- |
 | **`blob`**       | <code>Blob</code>   | The Blob instance of the file. Only available on Web.                                                                |       |
 | **`data`**       | <code>string</code> | The Base64 string representation of the data contained in the file. Is only provided if `readData` is set to `true`. |       |
-| **`duration`**   | <code>number</code> | The duration of the video in milliseconds. Only available on Android and iOS.                                        | 0.5.3 |
+| **`duration`**   | <code>number</code> | The duration of the video in seconds. Only available on Android and iOS.                                             | 0.5.3 |
 | **`height`**     | <code>number</code> | The height of the image or video in pixels. Only available on Android and iOS.                                       | 0.5.3 |
 | **`mimeType`**   | <code>string</code> | The mime type of the file.                                                                                           |       |
 | **`modifiedAt`** | <code>number</code> | The last modified timestamp of the file in milliseconds.                                                             | 0.5.9 |

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/filepicker/FilePicker.java
@@ -100,13 +100,13 @@ public class FilePicker {
             MediaMetadataRetriever retriever = new MediaMetadataRetriever();
             retriever.setDataSource(bridge.getContext(), uri);
             String time = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
-            long duration = Long.parseLong(time);
+            long durationMs = Long.parseLong(time);
             try {
                 retriever.release();
             } catch (Exception e) {
                 Logger.error(TAG, "MediaMetadataRetriever.release() failed.", e);
             }
-            return duration;
+            return durationMs / 1000l;
         }
         return null;
     }

--- a/ios/Plugin/FilePicker.swift
+++ b/ios/Plugin/FilePicker.swift
@@ -99,7 +99,7 @@ import MobileCoreServices
         do {
             let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
             if let modifiedDateInSec = (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 {
-                return Int(modifiedDateInSec) * 1000
+                return Int(modifiedDateInSec * 1000.0)
             } else {
                 return nil
             }
@@ -130,7 +130,7 @@ import MobileCoreServices
             let asset = AVAsset(url: url)
             let duration = asset.duration
             let durationTime = CMTimeGetSeconds(duration)
-            return Int(durationTime) * 1000
+            return Int(round(durationTime))
         }
         return nil
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -85,7 +85,7 @@ export interface File {
    */
   data?: string;
   /**
-   * The duration of the video in milliseconds.
+   * The duration of the video in seconds.
    *
    * Only available on Android and iOS.
    *


### PR DESCRIPTION
BREAKING CHANGE: `duration` is now returned in seconds and no longer in milliseconds.

Close #73 
Close #76 
